### PR TITLE
Use unique component name in transform-script.js

### DIFF
--- a/lib/transform-script.js
+++ b/lib/transform-script.js
@@ -55,7 +55,7 @@ module.exports = ({ script, template, style, emitCss, id: fileName }) => {
       ) {
         astExtend = transformToAst(
           astExtendFunction
-            .replace(/{{COMPONENT_NAME}}/g, `f7c42${id}`)
+            .replace(/{{COMPONENT_NAME}}/g, `f7component${id}`)
             .replace(/{{ASYNC}}/g, node.declaration.async ? 'async ' : ''),
         );
         astExtend.program.body[0].params = node.declaration.params;

--- a/lib/transform-script.js
+++ b/lib/transform-script.js
@@ -55,7 +55,7 @@ module.exports = ({ script, template, style, emitCss, id: fileName }) => {
       ) {
         astExtend = transformToAst(
           astExtendFunction
-            .replace(/{{COMPONENT_NAME}}/g, 'framework7Component')
+            .replace(/{{COMPONENT_NAME}}/g, `f7c42${id}`)
             .replace(/{{ASYNC}}/g, node.declaration.async ? 'async ' : ''),
         );
         astExtend.program.body[0].params = node.declaration.params;


### PR DESCRIPTION
See (https://github.com/framework7io/framework7/issues/4244) for more info

Avoid error `Error: InvalidCharacterError: Failed to execute 'createElement' on 'Document': The tag name provided ('$') is not a valid name.`

Name components using unique is as part of the coponent name function so they don't collide. This way rollup or other minifiers don't try to use $N in the names